### PR TITLE
time/color and time/y_spread

### DIFF
--- a/dual_display.py
+++ b/dual_display.py
@@ -208,8 +208,8 @@ def on_message(client, userdata, message):
     print "color change "+message.payload
     display.set_time_color(int(message.payload))
   elif message.topic == "display/time/y_spread":
-    print "y_spread change"+message.payload
-    display.set_y_spread(message.payload)
+    print "y_spread change "+message.payload
+    display.set_y_spread(int(message.payload))
   else:
     print "unknown topic: "+message.topic
 

--- a/dual_display.py
+++ b/dual_display.py
@@ -136,7 +136,7 @@ class Screen():
     for data_index in range(0,self.total_columns-1):
       new_x = last_x + 1 
       new_y = sound_data[data_index] 
-      self.draw.line((last_x, last_y-self.y_spread, new_x, new_y+self.y_spread),fill=time_color) 
+      self.draw.line((new_x, last_y - self.y_spread, new_x, new_y + self.y_spread),fill=time_color) 
       last_x = new_x
       last_y = new_y
 

--- a/dual_display.py
+++ b/dual_display.py
@@ -138,7 +138,7 @@ class Screen():
     for data_index in range(0,self.total_columns):
       new_x = last_x + 1 
       new_y = sound_data[data_index] 
-      self.draw.line((last_x, last_y - self.y_spread, last_x, new_y + self.y_spread),fill=time_color) 
+      self.draw.line((last_x, last_y - self.y_spread, last_x, last_y + self.y_spread),fill=time_color) 
       #self.draw.line((last_x, last_y - self.y_spread, new_x, new_y + self.y_spread),fill=time_color) 
       last_x = new_x
       last_y = new_y

--- a/dual_display.py
+++ b/dual_display.py
@@ -138,7 +138,7 @@ class Screen():
     for data_index in range(0,self.total_columns-1):
       new_x = last_x + 1 
       new_y = sound_data[data_index] 
-      self.draw.line((new_x, last_y - self.y_spread, new_x, new_y + self.y_spread),fill=time_color) 
+      self.draw.line((last_x, last_y - self.y_spread, last_x, new_y + self.y_spread),fill=time_color) 
       #self.draw.line((last_x, last_y - self.y_spread, new_x, new_y + self.y_spread),fill=time_color) 
       last_x = new_x
       last_y = new_y

--- a/dual_display.py
+++ b/dual_display.py
@@ -53,14 +53,14 @@ class Screen():
   # set_time_color 
   ###############################################
   def set_time_color(self, color):
-    if color >= 0 or color <= 360:
+    if color >= 0 and color <= 360:
       self.color = color
 
   ############################################
   # set_y_spread
   ###############################################
   def set_y_spread(self, y_thickness):
-    if y_thickness >= 0 or y_thickness<=4:
+    if y_thickness >= 0 and y_thickness<=4:
       self.y_spread = y_thickness 
 
 

--- a/dual_display.py
+++ b/dual_display.py
@@ -188,7 +188,7 @@ def on_message(client, userdata, message):
   elif message.topic == "display/freq/pixels_per_bin":
     display.set_freq_bin_num_pixels(message.payload)
   elif message.topic == "display/time/color":
-    print "color change "+message.payload:
+    print "color change "+message.payload
 
 #broker_address="10.0.0.17"
 broker_address="makerlabPi1"

--- a/dual_display.py
+++ b/dual_display.py
@@ -42,7 +42,7 @@ class Screen():
     
     self.set_color_palette()
     self.color = 150
-    self.y_spread = 1
+    self.y_spread = 2
   ############################################
   # set_client 
   ###############################################

--- a/dual_display.py
+++ b/dual_display.py
@@ -135,11 +135,11 @@ class Screen():
     time_color ="hsl({}, 100%, 50%)".format(self.color) 
     
 
-    for data_index in range(0,self.total_columns):
+    for data_index in range(0,self.total_columns-1):
       new_x = last_x + 1 
       new_y = sound_data[data_index] 
-      self.draw.line((last_x, last_y - self.y_spread, last_x, last_y + self.y_spread),fill=time_color) 
-      #self.draw.line((last_x, last_y - self.y_spread, new_x, new_y + self.y_spread),fill=time_color) 
+      #self.draw.line((last_x, last_y - self.y_spread, last_x, last_y + self.y_spread),fill=time_color) 
+      self.draw.line((last_x, last_y - self.y_spread, new_x, new_y + self.y_spread),fill=time_color) 
       last_x = new_x
       last_y = new_y
 

--- a/dual_display.py
+++ b/dual_display.py
@@ -52,7 +52,7 @@ class Screen():
   # set_time_color 
   ###############################################
   def set_time_color(self, color):
-    self.color = color
+    self.color = color%360 #hsl uses colors from 0-360
 
 
   ############################################
@@ -182,7 +182,7 @@ display = Screen(matrix_rows, matrix_columns, num_hor, num_vert)
 def on_message(client, userdata, message):
   global display
 
-  print "Message Callback"
+  #print "Message Callback"
 
   if message.topic == "audio/time_samples":
     sound_data = []

--- a/dual_display.py
+++ b/dual_display.py
@@ -42,6 +42,7 @@ class Screen():
     
     self.set_color_palette()
     self.color = 150
+    self.y_spread = 1
   ############################################
   # set_client 
   ###############################################
@@ -53,6 +54,12 @@ class Screen():
   ###############################################
   def set_time_color(self, color):
     self.color = color%360 #hsl uses colors from 0-360
+
+  ############################################
+  # set_y_spread
+  ###############################################
+  def set_y_spread(self, y_thickness):
+    self.y_spread = y_thickness 
 
 
   ############################################
@@ -124,12 +131,12 @@ class Screen():
     last_y = self.total_rows / 4
 
     time_color ="hsl({}, 100%, 50%)".format(self.color) 
-    y_spread = 1
     
+
     for data_index in range(0,self.total_columns-1):
       new_x = last_x + 1 
       new_y = sound_data[data_index] 
-      self.draw.line((last_x, last_y-y_spread, new_x, new_y+y_spread),fill=time_color) 
+      self.draw.line((last_x, last_y-self.y_spread, new_x, new_y+self.y_spread),fill=time_color) 
       last_x = new_x
       last_y = new_y
 
@@ -200,6 +207,9 @@ def on_message(client, userdata, message):
   elif message.topic == "display/time/color":
     print "color change "+message.payload
     display.set_time_color(int(message.payload))
+   elif message.topic == "display/time/y_spread":
+    print "y_spread change"+message.payload
+    display.set_y_spread(message.payload)
   else:
     print "unknown topic: "+message.topic
 
@@ -217,6 +227,7 @@ client.loop_start()
 client.subscribe("audio/#")
 client.subscribe("display/freq/#")
 client.subscribe("display/time/color")
+client.subscribe("display/time/y_spread")
 
 display.set_client(client)
 display.send_size()

--- a/dual_display.py
+++ b/dual_display.py
@@ -137,6 +137,7 @@ class Screen():
       new_x = last_x + 1 
       new_y = sound_data[data_index] 
       self.draw.line((new_x, last_y - self.y_spread, new_x, new_y + self.y_spread),fill=time_color) 
+      #self.draw.line((last_x, last_y - self.y_spread, new_x, new_y + self.y_spread),fill=time_color) 
       last_x = new_x
       last_y = new_y
 

--- a/dual_display.py
+++ b/dual_display.py
@@ -189,6 +189,8 @@ def on_message(client, userdata, message):
     display.set_freq_bin_num_pixels(message.payload)
   elif message.topic == "display/time/color":
     print "color change "+message.payload
+  else:
+    print "unknown topic: "+message.topic
 
 #broker_address="10.0.0.17"
 broker_address="makerlabPi1"

--- a/dual_display.py
+++ b/dual_display.py
@@ -173,7 +173,7 @@ display = Screen(matrix_rows, matrix_columns, num_hor, num_vert)
 def on_message(client, userdata, message):
   global display
 
-  #print "Message Callback"
+  print "Message Callback"
 
   if message.topic == "audio/time_samples":
     sound_data = []

--- a/dual_display.py
+++ b/dual_display.py
@@ -53,13 +53,15 @@ class Screen():
   # set_time_color 
   ###############################################
   def set_time_color(self, color):
-    self.color = color%360 #hsl uses colors from 0-360
+    if color >= 0 or color <= 360:
+      self.color = color
 
   ############################################
   # set_y_spread
   ###############################################
   def set_y_spread(self, y_thickness):
-    self.y_spread = y_thickness 
+    if y_thickness >= 0 or y_thickness<=4:
+      self.y_spread = y_thickness 
 
 
   ############################################

--- a/dual_display.py
+++ b/dual_display.py
@@ -163,10 +163,10 @@ class Screen():
 
     self.matrix.SetImage(self.screen,0,0)
 
-matrix_rows = 64
-matrix_columns = 64
-num_hor = 1
-num_vert = 1
+matrix_rows = 32
+matrix_columns = 32
+num_hor = 5
+num_vert = 3
 
 display = Screen(matrix_rows, matrix_columns, num_hor, num_vert)
 
@@ -187,9 +187,11 @@ def on_message(client, userdata, message):
     display.show_freq_data(sound_data)
   elif message.topic == "display/freq/pixels_per_bin":
     display.set_freq_bin_num_pixels(message.payload)
+  elif message.topic == "display/time/color":
+    print "color change "+message.payload:
 
 #broker_address="10.0.0.17"
-broker_address="raspberrypi_glenn"
+broker_address="makerlabPi1"
 client = mqtt.Client("dual_display")
 client.on_message=on_message
 try:
@@ -201,6 +203,7 @@ except:
 client.loop_start()
 client.subscribe("audio/#")
 client.subscribe("display/freq/#")
+client.subscribe("display/time/color")
 
 display.set_client(client)
 display.send_size()

--- a/dual_display.py
+++ b/dual_display.py
@@ -124,11 +124,12 @@ class Screen():
     last_y = self.total_rows / 4
 
     time_color ="hsl({}, 100%, 50%)".format(self.color) 
-
+    y_spread = 1
+    
     for data_index in range(0,self.total_columns-1):
       new_x = last_x + 1 
       new_y = sound_data[data_index] 
-      self.draw.line((last_x, last_y, new_x, new_y),fill=time_color) 
+      self.draw.line((last_x, last_y-y_spread, new_x, new_y+y_spread),fill=time_color) 
       last_x = new_x
       last_y = new_y
 

--- a/dual_display.py
+++ b/dual_display.py
@@ -139,7 +139,7 @@ class Screen():
       new_x = last_x + 1 
       new_y = sound_data[data_index] 
       #self.draw.line((last_x, last_y - self.y_spread, last_x, last_y + self.y_spread),fill=time_color) 
-      self.draw.line((last_x, last_y - self.y_spread, new_x, new_y + self.y_spread),fill=time_color) 
+      self.draw.line((last_x, last_y, new_x, new_y + self.y_spread),fill=time_color) 
       last_x = new_x
       last_y = new_y
 

--- a/dual_display.py
+++ b/dual_display.py
@@ -135,7 +135,7 @@ class Screen():
     time_color ="hsl({}, 100%, 50%)".format(self.color) 
     
 
-    for data_index in range(0,self.total_columns-1):
+    for data_index in range(0,self.total_columns):
       new_x = last_x + 1 
       new_y = sound_data[data_index] 
       self.draw.line((last_x, last_y - self.y_spread, last_x, new_y + self.y_spread),fill=time_color) 

--- a/dual_display.py
+++ b/dual_display.py
@@ -138,7 +138,7 @@ class Screen():
     for data_index in range(0,self.total_columns-1):
       new_x = last_x + 1 
       new_y = sound_data[data_index] 
-      self.draw.line((new_x, last_y - self.y_spread, new_x, new_y + self.y_spread),fill=time_color) 
+      self.draw.line((new_x, last_y, new_x, new_y + self.y_spread),fill=time_color) 
       #self.draw.line((last_x, last_y - self.y_spread, new_x, new_y + self.y_spread),fill=time_color) 
       last_x = new_x
       last_y = new_y

--- a/dual_display.py
+++ b/dual_display.py
@@ -138,7 +138,7 @@ class Screen():
     for data_index in range(0,self.total_columns-1):
       new_x = last_x + 1 
       new_y = sound_data[data_index] 
-      self.draw.line((new_x, last_y, new_x, new_y + self.y_spread),fill=time_color) 
+      self.draw.line((new_x, last_y - self.y_spread, new_x, new_y + self.y_spread),fill=time_color) 
       #self.draw.line((last_x, last_y - self.y_spread, new_x, new_y + self.y_spread),fill=time_color) 
       last_x = new_x
       last_y = new_y

--- a/dual_display.py
+++ b/dual_display.py
@@ -42,7 +42,7 @@ class Screen():
     
     self.set_color_palette()
     self.color = 150
-    self.y_spread = 2
+    self.y_spread = 0
   ############################################
   # set_client 
   ###############################################

--- a/dual_display.py
+++ b/dual_display.py
@@ -207,7 +207,7 @@ def on_message(client, userdata, message):
   elif message.topic == "display/time/color":
     print "color change "+message.payload
     display.set_time_color(int(message.payload))
-   elif message.topic == "display/time/y_spread":
+  elif message.topic == "display/time/y_spread":
     print "y_spread change"+message.payload
     display.set_y_spread(message.payload)
   else:

--- a/dual_display.py
+++ b/dual_display.py
@@ -41,12 +41,19 @@ class Screen():
     self.freq_display_style = "instant"
     
     self.set_color_palette()
-
+    self.color = 150
   ############################################
   # set_client 
   ###############################################
   def set_client(self, client):
     self.client = client
+
+  ############################################
+  # set_time_color 
+  ###############################################
+  def set_time_color(self, color):
+    self.color = color
+
 
   ############################################
   # set_color_palette
@@ -116,10 +123,12 @@ class Screen():
     last_x = 0
     last_y = self.total_rows / 4
 
+    time_color ="hsl({}, 100%, 50%)".format(self.color) 
+
     for data_index in range(0,self.total_columns-1):
       new_x = last_x + 1 
       new_y = sound_data[data_index] 
-      self.draw.line((last_x, last_y, new_x, new_y),fill=(0,0,255)) 
+      self.draw.line((last_x, last_y, new_x, new_y),fill=time_color) 
       last_x = new_x
       last_y = new_y
 
@@ -189,6 +198,7 @@ def on_message(client, userdata, message):
     display.set_freq_bin_num_pixels(message.payload)
   elif message.topic == "display/time/color":
     print "color change "+message.payload
+    display.set_time_color(int(message.payload))
   else:
     print "unknown topic: "+message.topic
 

--- a/mic_full.py
+++ b/mic_full.py
@@ -114,7 +114,7 @@ def on_message(client, userdata, message):
     print("Payload: "+message.payload)
 
 #broker_address="10.0.0.17"
-broker_address="raspberrypi_glenn"
+broker_address="makerlabPi1"
 client = mqtt.Client("Microphone")
 client.on_message=on_message
 try:


### PR DESCRIPTION
added MQTT controls for color of time graph (limited to 0-360) and thickening the line drawn for time using the y_spread argument.

Side note: Wondering how you adjust an argument using the +/- as opposed to just setting a value using a message.payload?